### PR TITLE
Version 0.15.13

### DIFF
--- a/de.schmidhuberj.Flare.json
+++ b/de.schmidhuberj.Flare.json
@@ -15,7 +15,6 @@
         "--device=dri",
         "--share=network",
         "--talk-name=org.freedesktop.secrets",
-        "--talk-name=org.sigxcpu.Feedback",
         "--system-talk-name=org.freedesktop.login1"
     ],
     "build-options": {
@@ -121,8 +120,8 @@
                 {
                     "type": "archive",
                     "archive-type": "tar-xz",
-                    "url": "https://gitlab.com/schmiddi-on-mobile/flare/-/package_files/178184559/download",
-                    "sha256": "9d6b447c5d9bd074ca2569f87707e46e5b52fdcc8a5b4320d72b3b4e48fdeb6b"
+                    "url": "https://gitlab.com/api/v4/projects/37464215/packages/generic/flare/0.15.13/flare-0.15.13.tar.xz",
+                    "sha256": "181dbf5e56f511fde54a29c9102dc345bcdc4e7be577a6b41c9daf7fd55a6690"
                 }
             ]
         }


### PR DESCRIPTION
This removes the "org.sigxcpu.Feedback" permission, as feedback is not yet handled anymore by Flare, but should be handled by the notification daemon.