### PR TITLE
Version 0.17.1

### DIFF
--- a/de.schmidhuberj.Flare.json
+++ b/de.schmidhuberj.Flare.json
@@ -124,7 +124,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/whisperfish/presage.git",
-                    "commit": "123c1f926e359c21b34d099279ee8a92462ce96d",
+                    "commit": "31a418d0a35ad746590165520b652d6adb7a0384",
                     "dest": "presage"
                 },
                 {


### PR DESCRIPTION
This removes two permissions:

- `--talk-name=org.freedesktop.secrets` was actually not required for quite a while (I think since we switched to `oo7`, the secerts are stored directly in the Flatpak).
- `--system-talk-name=org.freedesktop.login1`: I found an alternative way to restart the backend client code when waking up from suspend: Just restart whenever the network changes to "connected".