### PR TITLE
Remove blueprint-compiler

### DIFF
--- a/de.schmidhuberj.Flare.json
+++ b/de.schmidhuberj.Flare.json
@@ -1,7 +1,7 @@
 {
     "app-id": "de.schmidhuberj.Flare",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Included in the SDK since GNOME 49.